### PR TITLE
Fallen pc implimentation

### DIFF
--- a/css/die-rpg.css
+++ b/css/die-rpg.css
@@ -985,6 +985,84 @@
 .die-rpg.actor .window-content .sheet-header .header-top .flashback-indicator .reset-flashback-btn i {
   pointer-events: none;
 }
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator {
+  display: flex;
+  align-items: center;
+  margin-top: 5px;
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--die-rpg-overlay-dark);
+  border: 1px solid var(--die-rpg-overlay-dark);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 0.9em;
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle i {
+  font-size: 1em;
+  color: var(--die-rpg-c-success);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle .label {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle:hover {
+  background: var(--die-rpg-overlay-darker);
+  border-color: var(--die-rpg-overlay-medium);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle:hover i {
+  color: var(--die-rpg-c-white);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle:hover .label {
+  color: var(--die-rpg-c-white);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle.active {
+  background: var(--die-rpg-c-failure-bg);
+  border-color: var(--die-rpg-c-failure-border);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle.active i {
+  color: var(--die-rpg-c-failure);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle.active .label {
+  color: var(--die-rpg-c-failure);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle.active:hover {
+  background: rgba(139, 0, 0, 0.3);
+  border-color: var(--die-rpg-c-failure);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle.active:hover i,
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-toggle.active:hover .label {
+  filter: brightness(1.2);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-display {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--die-rpg-overlay-darker);
+  border-radius: 4px;
+  opacity: 0.8;
+  font-size: 0.9em;
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-display i {
+  font-size: 1em;
+  color: var(--die-rpg-c-success);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-display .label {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-display.active {
+  background: var(--die-rpg-c-failure-bg);
+}
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-display.active i,
+.die-rpg.actor .window-content .sheet-header .header-top .fallen-mode-indicator .fallen-mode-display.active .label {
+  color: var(--die-rpg-c-failure);
+}
 .die-rpg.actor .window-content .sheet-header .header-top .paragon-selection {
   display: flex;
   align-items: center;
@@ -2285,6 +2363,271 @@
   align-items: center;
   gap: 10px;
 }
+.die-rpg .tab.paragon .fallen-mode-section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.die-rpg .tab.paragon .fallen-state-info {
+  padding: 20px;
+  background: var(--die-rpg-overlay-dark);
+  border: 1px solid var(--die-rpg-overlay-medium);
+  border-radius: 4px;
+}
+.die-rpg .tab.paragon .fallen-state-info .section-title {
+  margin: 0 0 5px 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--die-rpg-c-failure);
+}
+.die-rpg .tab.paragon .fallen-state-info .fallen-description {
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.9);
+}
+.die-rpg .tab.paragon .fallen-rules {
+  padding: 20px;
+  background: var(--die-rpg-overlay-darker);
+  border-left: 3px solid var(--die-rpg-overlay-medium);
+  border-radius: 2px;
+}
+.die-rpg .tab.paragon .fallen-rules h4 {
+  margin: 0 0 5px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+.die-rpg .tab.paragon .fallen-rules .rules-list {
+  margin: 0;
+  padding-left: 1.5rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+.die-rpg .tab.paragon .fallen-rules .rules-list li {
+  margin-bottom: 5px;
+  line-height: 1.5;
+}
+.die-rpg .tab.paragon .fallen-rules .rules-list li:last-child {
+  margin-bottom: 0;
+}
+.die-rpg .tab.paragon .fallen-claws {
+  padding: 20px;
+  background: var(--die-rpg-overlay-dark);
+  border: 1px solid var(--die-rpg-overlay-medium);
+  border-radius: 4px;
+}
+.die-rpg .tab.paragon .fallen-claws h4 {
+  margin: 0 0 5px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+.die-rpg .tab.paragon .fallen-claws .claws-description {
+  margin-bottom: 10px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.9);
+}
+.die-rpg .tab.paragon .fallen-claws .poison-special {
+  padding: 10px;
+  background: var(--die-rpg-overlay-darker);
+  border-left: 3px solid var(--die-rpg-c-failure-border);
+  border-radius: 2px;
+}
+.die-rpg .tab.paragon .fallen-claws .poison-special strong {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--die-rpg-c-failure);
+  font-size: 0.95rem;
+}
+.die-rpg .tab.paragon .fallen-claws .poison-special p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.85);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-header h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-header .add-ability-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background: var(--die-rpg-c-success-bg);
+  color: var(--die-rpg-c-success-text);
+  border: 1px solid var(--die-rpg-c-success-border);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-header .add-ability-btn i {
+  font-size: 0.625rem;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-header .add-ability-btn:hover {
+  background: var(--die-rpg-c-success);
+  border-color: var(--die-rpg-c-success);
+  color: var(--die-rpg-c-white);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .abilities-list .hint-text {
+  margin: 0;
+  padding: 10px;
+  font-size: 0.875rem;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.6);
+  background: var(--die-rpg-overlay-darker);
+  border-radius: 3px;
+  text-align: center;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block {
+  padding: 10px;
+  background: var(--die-rpg-overlay-dark);
+  border: 1px solid var(--die-rpg-overlay-medium);
+  border-radius: 4px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header input[type=text] {
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  background: var(--die-rpg-overlay-darker);
+  border: 1px solid var(--die-rpg-overlay-medium);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.95);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header input[type=text]:focus {
+  outline: none;
+  border-color: var(--die-rpg-overlay-light);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header input[type=text]:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header .delete-ability-btn {
+  padding: 0.25rem 0.5rem;
+  background: var(--die-rpg-c-failure-bg);
+  color: var(--die-rpg-c-failure);
+  border: 1px solid var(--die-rpg-c-failure-border);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header .delete-ability-btn i {
+  font-size: 0.75rem;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-header .delete-ability-btn:hover {
+  background: var(--die-rpg-c-failure);
+  border-color: var(--die-rpg-c-failure);
+  color: var(--die-rpg-c-white);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-description,
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-customization {
+  margin-bottom: 10px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-description label,
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-customization label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-description prose-mirror,
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-customization prose-mirror {
+  min-height: 100px;
+  background: var(--die-rpg-overlay-darker);
+  border: 1px solid var(--die-rpg-overlay-medium);
+  border-radius: 3px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials {
+  margin-top: 20px;
+  padding-top: 10px;
+  border-top: 1px solid var(--die-rpg-overlay-medium);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .specials-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .specials-header label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .specials-header .add-special-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background: var(--die-rpg-c-success-bg);
+  color: var(--die-rpg-c-success-text);
+  border: 1px solid var(--die-rpg-c-success-border);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .specials-header .add-special-btn i {
+  font-size: 0.625rem;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .specials-header .add-special-btn:hover {
+  background: var(--die-rpg-c-success);
+  border-color: var(--die-rpg-c-success);
+  color: var(--die-rpg-c-white);
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .specials-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.die-rpg .tab.paragon .monstrous-abilities-container .monstrous-ability-block .ability-specials .hint-text {
+  margin: 0;
+  padding: 5px;
+  font-size: 0.875rem;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.6);
+  background: var(--die-rpg-overlay-darkest);
+  border-radius: 3px;
+}
+.die-rpg .tab.paragon .second-death-warning {
+  padding: 20px;
+  background: var(--die-rpg-overlay-dark);
+  border: 1px solid var(--die-rpg-overlay-medium);
+  border-left: 3px solid var(--die-rpg-c-failure-border);
+  border-radius: 4px;
+}
+.die-rpg .tab.paragon .second-death-warning h4 {
+  margin: 0 0 5px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--die-rpg-c-failure);
+}
+.die-rpg .tab.paragon .second-death-warning .warning-text {
+  margin: 0;
+  line-height: 1.5;
+  font-size: 0.9375rem;
+  color: rgba(255, 255, 255, 0.9);
+}
 .die-rpg .tab.persona {
   padding: 10px;
 }
@@ -2528,5 +2871,3 @@
 .die-rpg .tab.npc-abilities .empty-state .hint-text {
   font-size: 0.9rem;
 }
-
-/*# sourceMappingURL=die-rpg.css.map */

--- a/lang/en.json
+++ b/lang/en.json
@@ -56,6 +56,26 @@
 						"label": "Flashback Used",
 						"hint": "Whether the character has used their once-per-session flashback"
 					},
+					"fallenMode": {
+						"label": "Fallen Mode",
+						"hint": "Whether this character has died and become a Fallen"
+					},
+					"monstrousAbilities": {
+						"label": "Monstrous Abilities",
+						"hint": "Abilities gained upon becoming Fallen"
+					},
+					"monstrousAbility": {
+						"name": { "label": "Ability Name" },
+						"description": {
+							"label": "Description",
+							"hint": "What this monstrous ability does"
+						},
+						"customization": {
+							"label": "Customization",
+							"hint": "Describe what this looks/sounds like for your character"
+						},
+						"specials": { "label": "Specials" }
+					},
 					"paragon": {
 						"classAbilityData": {
 							"label": "Class Ability Data",
@@ -406,6 +426,72 @@
 			"Passive": "Passive Effects",
 			"Inactive": "Inactive Effects"
 		},
+		"FallenMode": {
+			"LabelLiving": "Living",
+			"LabelFallen": "Fallen",
+			"TooltipEnterFallen": "Click to enter Fallen mode",
+			"TooltipReturnToLiving": "Click to return to Living mode",
+			"Title": "You Are Fallen",
+			"Description": "You are an undead monster. If you kill one of the other player characters, you become alive again.",
+			"UnlifeRules": {
+				"Title": "Unlife After Death",
+				"LostAbilities": "You lose access to any special abilities granted by your class, but keep your stats and equipment.",
+				"Resurrection": "If you provide the killing Wound to another Persona-controlled character, you immediately come to life and regain all your class abilities.",
+				"VoteDoesNotCount": "Your vote to go home no longer counts, because you're dead."
+			},
+			"FallenClaws": {
+				"Title": "Fallen Claws",
+				"Description": "While your old weaponry might look the same, it's changed. Many Fallen abandon the pretence, lose their weapons, and attack with claws sprouting from their body.",
+				"PoisonLabel": "Special: Poison",
+				"PoisonEffect": "All attacks you make gain Special: if this attack causes a Wound the target is poisoned. (Lose 1 Health per round until a character succeeds a Constitution test.)"
+			},
+			"SecondDeath": {
+				"Title": "Second Death?",
+				"Description": "You're dead. At least the worst has happened, right? If you die again, you will rise again at the end of the encounter. You have a nagging feeling there are only so many times this can happen before you lose something fundamental. (You're right.)"
+			},
+			"MonstrousAbilities": {
+				"Title": "Monstrous Abilities",
+				"AddButton": "Add Ability",
+				"AddTooltip": "Add a new monstrous ability",
+				"DeleteTooltip": "Delete this monstrous ability",
+				"NewAbility": "New Monstrous Ability",
+				"NamePlaceholder": "Ability Name",
+				"DescriptionLabel": "Description",
+				"CustomizationLabel": "Customization (what does this look/sound like?)",
+				"SpecialsLabel": "Specials",
+				"AddSpecialButton": "Add Special",
+				"AddSpecialTooltip": "Add a special to this ability",
+				"NoSpecials": "No specials defined for this ability",
+				"NoAbilities": "No monstrous abilities. Click 'Add Ability' to create one."
+			}
+		},
+		"MonstrousAbilities": {
+			"Flight": {
+				"name": "Flight",
+				"description": "<p>You are able to soar through the sky at a sprinting pace.</p>",
+				"customizationPrompt": "<p><em>Decide what this looks like:</em></p><ul><li>Wings</li><li>Thrusters</li><li>Enormous blood-coated springs</li><li>Something else</li></ul>"
+			},
+			"Intangibility": {
+				"name": "Intangibility",
+				"description": "<p>You are able to move spectrally through objects that bar your path. (This gives you no specific bonus to resist damage.)</p>",
+				"customizationPrompt": "<p><em>Decide what this looks like:</em></p><ul><li>Classic spectral</li><li>A burst of digital noise</li><li>Transformation into burrowing worms</li><li>Something else</li></ul>"
+			},
+			"UncannyScenes": {
+				"name": "Uncanny Senses",
+				"description": "<p>You can perceive things far beyond normal human capabilities.</p>",
+				"customizationPrompt": "<p><em>Decide which type of thing you can sense:</em></p><ul><li>Strong emotions</li><li>Heartbeats and breathing</li><li>Narrative</li><li>Something else</li></ul>"
+			},
+			"SizeChanging": {
+				"name": "Size Changing",
+				"description": "<p>You can swell to four times your height or shrink to a tenth of your size.</p>",
+				"customizationPrompt": "<p><em>Decide what this looks and/or sounds like:</em></p><ul><li>Cracking gristle and bone</li><li>Folding and unfolding fractal limbs</li><li>An incongruous slide-whistle</li><li>Something else</li></ul>"
+			},
+			"ShapeChanging": {
+				"name": "Shape Changing",
+				"description": "<p>You can change your form to appear to be something else... until you attack.</p>",
+				"customizationPrompt": "<p><em>Decide what your tell is, no matter your form:</em></p><ul><li>Your voice remains an awful undead crackle</li><li>You smell like the rotting flesh you are</li><li>All animals view you with fear and suspicion</li><li>Something else</li></ul>"
+			}
+		},
 		"Class": {
 			"Dictator": "Dictator",
 			"Fool": "Fool",
@@ -583,8 +669,12 @@
 				"EquipmentOptionAdded": "{name} added to equipment options",
 				"EquipmentOptionRemoved": "Equipment option removed",
 				"EquipmentAddedToInventory": "{name} added to inventory",
+				"FallenModeEnabled": "Character has fallen. They are now undead.",
+				"FallenModeDisabled": "Character returned to life.",
 				"AbilityAdded": "Ability added successfully.",
 				"AbilityDeleted": "Ability deleted successfully.",
+				"MonstrousAbilityAdded": "Monstrous ability added successfully.",
+				"MonstrousAbilityDeleted": "Monstrous ability deleted successfully.",
 				"SpecialAdded": "Special added successfully.",
 				"SpecialDeleted": "Special deleted successfully."
 			},

--- a/lang/en.json
+++ b/lang/en.json
@@ -93,7 +93,8 @@
 						"notes": { "label": "Notes" }
 					}
 				},
-				"ResetFlashback": "Reset Flashback"
+				"ResetFlashback": "Reset Flashback",
+				"FlashbackAvailable": "Flashback Available"
 			},
 			"NPC": {
 				"FIELDS": {
@@ -686,6 +687,9 @@
 				"MonstrousAbilityDeleted": "Monstrous ability deleted successfully.",
 				"SpecialAdded": "Special added successfully.",
 				"SpecialDeleted": "Special deleted successfully."
+			},
+			"Info": {
+				"FlashbackAlreadyAvailable": "Flashback is already available."
 			},
 			"Warning": {
 				"NoParagon": "No paragon item found.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -36,6 +36,7 @@
 		"Actor": {
 			"Tabs": {
 				"Paragon": "Paragon",
+				"Fallen": "Fallen",
 				"Advancements": "Advancements",
 				"Loadout": "Loadout",
 				"Persona": "Persona",
@@ -591,6 +592,14 @@
 			"enableDiceInteraction": {
 				"name": "Enable Interactive Dice",
 				"hint": "Allows clicking success dice in chat messages to change which dice appear crossed out by difficulty. This is visual only - the final success count is always based on difficulty."
+			},
+			"fallenGameMode": {
+				"name": "Fallen Game Mode",
+				"hint": "Choose how Fallen characters work. Rituals mode: Fallen lose all paragon powers immediately (best for one-shots). Campaign mode: Fallen keep all paragon powers until second death (best for longer campaigns).",
+				"choices": {
+					"rituals": "Rituals (lose all powers)",
+					"campaign": "Campaign (keep powers until 2nd death)"
+				}
 			}
 		},
 		"Dialog": {

--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -1,5 +1,50 @@
-import { requiredInteger, setOptions } from "../helpers.mjs";
+import { requiredInteger, setOptions, specialsArrayField } from "../helpers.mjs";
 import DieRpgActorBase from './base.mjs';
+
+/**
+ * Returns the default set of 5 monstrous abilities from the DIE RPG rulebook.
+ * Characters can edit, delete, or add to these as needed.
+ * @returns {Array} Array of 5 default monstrous ability objects
+ */
+function getDefaultMonstrousAbilities() {
+  // Safely access game.i18n, with fallback if not yet initialized
+  const localize = (key, fallback) => {
+    return game?.i18n?.localize?.(key) ?? fallback;
+  };
+
+  return [
+    {
+      name: localize('DIE_RPG.MonstrousAbilities.Flight.name', 'Flight'),
+      description: localize('DIE_RPG.MonstrousAbilities.Flight.description', '<p>You are able to soar through the sky at a sprinting pace.</p>'),
+      customization: localize('DIE_RPG.MonstrousAbilities.Flight.customizationPrompt', '<p><em>Decide what this looks like:</em></p><ul><li>Wings</li><li>Thrusters</li><li>Enormous blood-coated springs</li><li>Something else</li></ul>'),
+      specials: []
+    },
+    {
+      name: localize('DIE_RPG.MonstrousAbilities.Intangibility.name', 'Intangibility'),
+      description: localize('DIE_RPG.MonstrousAbilities.Intangibility.description', '<p>You are able to move spectrally through objects that bar your path. (This gives you no specific bonus to resist damage.)</p>'),
+      customization: localize('DIE_RPG.MonstrousAbilities.Intangibility.customizationPrompt', '<p><em>Decide what this looks like:</em></p><ul><li>Classic spectral</li><li>A burst of digital noise</li><li>Transformation into burrowing worms</li><li>Something else</li></ul>'),
+      specials: []
+    },
+    {
+      name: localize('DIE_RPG.MonstrousAbilities.UncannyScenes.name', 'Uncanny Senses'),
+      description: localize('DIE_RPG.MonstrousAbilities.UncannyScenes.description', '<p>You can perceive things far beyond normal human capabilities.</p>'),
+      customization: localize('DIE_RPG.MonstrousAbilities.UncannyScenes.customizationPrompt', '<p><em>Decide which type of thing you can sense:</em></p><ul><li>Strong emotions</li><li>Heartbeats and breathing</li><li>Narrative</li><li>Something else</li></ul>'),
+      specials: []
+    },
+    {
+      name: localize('DIE_RPG.MonstrousAbilities.SizeChanging.name', 'Size Changing'),
+      description: localize('DIE_RPG.MonstrousAbilities.SizeChanging.description', '<p>You can swell to four times your height or shrink to a tenth of your size.</p>'),
+      customization: localize('DIE_RPG.MonstrousAbilities.SizeChanging.customizationPrompt', '<p><em>Decide what this looks and/or sounds like:</em></p><ul><li>Cracking gristle and bone</li><li>Folding and unfolding fractal limbs</li><li>An incongruous slide-whistle</li><li>Something else</li></ul>'),
+      specials: []
+    },
+    {
+      name: localize('DIE_RPG.MonstrousAbilities.ShapeChanging.name', 'Shape Changing'),
+      description: localize('DIE_RPG.MonstrousAbilities.ShapeChanging.description', '<p>You can change your form to appear to be something else... until you attack.</p>'),
+      customization: localize('DIE_RPG.MonstrousAbilities.ShapeChanging.customizationPrompt', '<p><em>Decide what your tell is, no matter your form:</em></p><ul><li>Your voice remains an awful undead crackle</li><li>You smell like the rotting flesh you are</li><li>All animals view you with fear and suspicion</li><li>Something else</li></ul>'),
+      specials: []
+    }
+  ];
+}
 
 /**
  * Data model for characters controlled by players.
@@ -23,6 +68,43 @@ export default class DieRpgCharacter extends DieRpgActorBase {
       label: 'DIE_RPG.Actor.Character.FIELDS.flashbackUsed.label',
       hint: 'DIE_RPG.Actor.Character.FIELDS.flashbackUsed.hint'
     });
+
+    schema.fallenMode = new fields.BooleanField({
+      required: true,
+      initial: false,
+      label: 'DIE_RPG.Actor.Character.FIELDS.fallenMode.label',
+      hint: 'DIE_RPG.Actor.Character.FIELDS.fallenMode.hint'
+    });
+
+    schema.monstrousAbilities = new fields.ArrayField(
+      new fields.SchemaField({
+        name: new fields.StringField({
+          required: true,
+          blank: false,
+          label: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbility.name.label'
+        }),
+        description: new fields.HTMLField({
+          required: true,
+          blank: true,
+          label: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbility.description.label',
+          hint: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbility.description.hint'
+        }),
+        customization: new fields.HTMLField({
+          required: true,
+          blank: true,
+          label: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbility.customization.label',
+          hint: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbility.customization.hint'
+        }),
+        specials: specialsArrayField({
+          label: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbility.specials.label'
+        })
+      }),
+      {
+        label: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbilities.label',
+        hint: 'DIE_RPG.Actor.Character.FIELDS.monstrousAbilities.hint',
+        initial: getDefaultMonstrousAbilities
+      }
+    );
 
     schema.paragon = new fields.SchemaField({
       uuid: new fields.StringField({ required: false, blank: true, initial: '' }),
@@ -88,5 +170,19 @@ export default class DieRpgCharacter extends DieRpgActorBase {
     data.lvl = this.level;
 
     return data
+  }
+
+  /**
+   * @override
+   * Prepare derived data after initialization.
+   * Auto-populate monstrousAbilities if character is fallen but has no abilities.
+   */
+  prepareDerivedData() {
+    super.prepareDerivedData?.();
+
+    // If character is in fallen mode but has no monstrous abilities, populate with defaults
+    if (this.fallenMode && (!this.monstrousAbilities || this.monstrousAbilities.length === 0)) {
+      this.monstrousAbilities = getDefaultMonstrousAbilities();
+    }
   }
 }

--- a/module/die-rpg.mjs
+++ b/module/die-rpg.mjs
@@ -120,6 +120,19 @@ Hooks.once('init', function () {
     default: true // Enabled by default
   });
 
+  game.settings.register('die-rpg', 'fallenGameMode', {
+    name: 'DIE_RPG.Settings.fallenGameMode.name',
+    hint: 'DIE_RPG.Settings.fallenGameMode.hint',
+    scope: 'world', // GM controls this setting per world
+    config: true, // Show in settings menu
+    type: String,
+    choices: {
+      'rituals': 'DIE_RPG.Settings.fallenGameMode.choices.rituals',
+      'campaign': 'DIE_RPG.Settings.fallenGameMode.choices.campaign'
+    },
+    default: 'rituals'
+  });
+
   utils.registerHandlebarsHelpers();
   // Preload Handlebars parts.
   utils.preloadHandlebarsTemplates();

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -51,7 +51,7 @@ export async function rollStat(dataset, actor) {
   // Update actor's flashback state if it was used
   if (flashbackUsed && actor && !actor.system.flashbackUsed) {
     await actor.update({ 'system.flashbackUsed': true });
-    actor.sheet?.render(false, {force: true});
+    actor.sheet?.render(false, {force: true, window: {controls: true}});
   }
  
   // Pass classDieType to _rollDicePool

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -83,6 +83,11 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
       classes: ["scrollable"],
       scrollable: [""],
     },
+    fallen: {
+      template: 'systems/die-rpg/templates/actor/fallen.hbs',
+      classes: ["scrollable"],
+      scrollable: [""],
+    },
     advancements: {
       template: 'systems/die-rpg/templates/actor/advancements.hbs',
       classes: ["scrollable"],
@@ -128,7 +133,26 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
     switch (this.document.type) {
       case 'character':
         options.parts = ['character-header', 'character-sidebar', 'stats', 'tabs'];
-        options.parts.push('paragon', 'advancements', 'loadout', 'persona', 'notes');
+
+        // Conditionally show Paragon and/or Fallen tabs based on fallenMode and game mode
+        const gameMode = game.settings.get('die-rpg', 'fallenGameMode');
+        const isFallen = this.document.system.fallenMode;
+
+        if (isFallen) {
+          if (gameMode === 'campaign') {
+            // Campaign mode: Show both Paragon and Fallen tabs
+            options.parts.push('paragon', 'fallen');
+          } else {
+            // Rituals mode: Only show Fallen tab (lose all paragon powers)
+            options.parts.push('fallen');
+          }
+        } else {
+          // Living character: Only show Paragon tab
+          options.parts.push('paragon');
+        }
+
+        // Always show other tabs
+        options.parts.push('advancements', 'loadout', 'persona', 'notes');
         break;
       case 'npc':
         // NPCs have no header - name is in sidebar
@@ -270,6 +294,9 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
       case 'paragon':
         context.tab = context.tabs[partId];
         break;
+      case 'fallen':
+        context.tab = context.tabs[partId];
+        break;
       case 'persona':
         context.tab = context.tabs[partId];
         // Enrich persona notes for display
@@ -378,6 +405,10 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
         case 'paragon':
           tab.id = 'paragon';
           tab.label += 'Paragon';
+          break;
+        case 'fallen':
+          tab.id = 'fallen';
+          tab.label += 'Fallen';
           break;
         case 'advancements':
           tab.id = 'advancements';

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -34,11 +34,14 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
       toggleAdvancement: this._toggleAdvancement,
       viewParagon: this._viewParagon,
       resetFlashback: this._resetFlashback,
+      toggleFallenMode: this._toggleFallenMode,
       createItemForList: this._onCreateItemForList,
       toggleItemDetails: this._onToggleItemDetails,
       addEquipmentFromParagon: this._addEquipmentFromParagon,
       addAbility: this._addAbility,
       deleteAbility: this._deleteAbility,
+      addMonstrousAbility: this._addMonstrousAbility,
+      deleteMonstrousAbility: this._deleteMonstrousAbility,
       addSpecial: this._addSpecial,
       deleteSpecial: this._deleteSpecial,
     },
@@ -503,6 +506,43 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
       });
     }
 
+    // For character actors, deep merge nested monstrousAbilities array updates
+    // Same logic as NPC abilities above
+    if (this.document.type === 'character' && expandedData.system?.monstrousAbilities) {
+      const currentAbilities = foundry.utils.deepClone(this.document.system.monstrousAbilities || []);
+      const updatedAbilities = expandedData.system.monstrousAbilities;
+
+      // Handle malformed empty-key specials (defensive fallback for template context issues)
+      if (updatedAbilities[""] && updatedAbilities[""].specials && currentAbilities.length > 0) {
+        updatedAbilities[0] = updatedAbilities[0] || {};
+        updatedAbilities[0].specials = updatedAbilities[""].specials;
+        delete updatedAbilities[""];
+      }
+
+      expandedData.system.monstrousAbilities = currentAbilities.map((ability, index) => {
+        if (!updatedAbilities[index]) return ability;
+
+        // Create a copy of the update without specials
+        const updateWithoutSpecials = foundry.utils.deepClone(updatedAbilities[index]);
+        delete updateWithoutSpecials.specials;
+
+        // Merge ability-level fields (excluding specials)
+        const merged = foundry.utils.mergeObject(ability, updateWithoutSpecials, {inplace: false});
+
+        // Deep merge specials array if it exists in the update
+        if (updatedAbilities[index].specials && ability.specials) {
+          merged.specials = ability.specials.map((special, specIdx) => {
+            if (updatedAbilities[index].specials[specIdx]) {
+              return foundry.utils.mergeObject(special, updatedAbilities[index].specials[specIdx], {inplace: false});
+            }
+            return special;
+          });
+        }
+
+        return merged;
+      });
+    }
+
     return expandedData;
   }
 
@@ -764,6 +804,78 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
     event.preventDefault();
     await this.actor.update({ 'system.flashbackUsed': false });
     ui.notifications.info(game.i18n.localize("DIE_RPG.Notifications.Success.FlashbackReset"));
+  }
+
+  /**
+   * Handle toggling fallen mode on/off
+   *
+   * @this DieRpgActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @protected
+   */
+  static async _toggleFallenMode(event, target) {
+    event.preventDefault();
+    const newState = !this.actor.system.fallenMode;
+    await this.actor.update({ 'system.fallenMode': newState });
+
+    const messageKey = newState
+      ? "DIE_RPG.Notifications.Success.FallenModeEnabled"
+      : "DIE_RPG.Notifications.Success.FallenModeDisabled";
+    ui.notifications.info(game.i18n.localize(messageKey));
+  }
+
+  /**
+   * Add a new monstrous ability to a character's monstrousAbilities array
+   *
+   * @this DieRpgActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The button element
+   * @protected
+   */
+  static async _addMonstrousAbility(event, target) {
+    event.preventDefault();
+
+    const abilities = this.actor.system.monstrousAbilities || [];
+    const newAbility = {
+      name: game.i18n.localize("DIE_RPG.FallenMode.MonstrousAbilities.NewAbility"),
+      description: '',
+      customization: '',
+      specials: [],
+    };
+
+    await this.actor.update({
+      'system.monstrousAbilities': [...abilities, newAbility]
+    });
+
+    ui.notifications.info(game.i18n.localize("DIE_RPG.Notifications.Success.MonstrousAbilityAdded"));
+  }
+
+  /**
+   * Delete a monstrous ability from a character's monstrousAbilities array
+   *
+   * @this DieRpgActorSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The button element
+   * @protected
+   */
+  static async _deleteMonstrousAbility(event, target) {
+    event.preventDefault();
+
+    const abilityIndex = parseInt(target.dataset.abilityIndex);
+    if (isNaN(abilityIndex)) {
+      console.warn('DIE RPG | Invalid monstrous ability index for deletion');
+      return;
+    }
+
+    const abilities = [...this.actor.system.monstrousAbilities];
+    abilities.splice(abilityIndex, 1);
+
+    await this.actor.update({
+      'system.monstrousAbilities': abilities
+    });
+
+    ui.notifications.info(game.i18n.localize("DIE_RPG.Notifications.Success.MonstrousAbilityDeleted"));
   }
 
   /**

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -165,6 +165,45 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
   /* -------------------------------------------- */
 
   /**
+   * Get header controls for the application window
+   * @returns {ApplicationHeaderControlsEntry[]} Array of control entries
+   * @protected
+   * @override
+   */
+  _getHeaderControls() {
+    const controls = super._getHeaderControls();
+
+    // Only add controls for character sheets
+    if (this.document.type !== 'character') return controls;
+
+    // Fallen Mode Toggle - always visible if editable
+    if (this.isEditable) {
+      controls.unshift({
+        icon: this.actor.system.fallenMode ? "fa-solid fa-skull" : "fa-solid fa-heart",
+        label: this.actor.system.fallenMode
+          ? "DIE_RPG.FallenMode.TooltipReturnToLiving"
+          : "DIE_RPG.FallenMode.TooltipEnterFallen",
+        action: "toggleFallenMode"
+      });
+    }
+
+    // Flashback Reset - always enabled, label changes based on state
+    if (this.isEditable) {
+      controls.unshift({
+        icon: "fa-solid fa-history",
+        label: this.actor.system.flashbackUsed
+          ? "DIE_RPG.Actor.Character.ResetFlashback"     // "Reset Flashback"
+          : "DIE_RPG.Actor.Character.FlashbackAvailable", // "Flashback Available"
+        action: "resetFlashback"
+      });
+    }
+
+    return controls;
+  }
+
+  /* -------------------------------------------- */
+
+  /**
    * Enrich HTML content for dynamic fields
    * @param {Array} fieldDefinitions - Array of field definitions from paragon
    * @param {Object} fieldData - Object containing field values
@@ -833,8 +872,18 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
    */
   static async _resetFlashback(event, target) {
     event.preventDefault();
+
+    // If flashback is already available, show info message
+    if (!this.actor.system.flashbackUsed) {
+      ui.notifications.info(game.i18n.localize("DIE_RPG.Notifications.Info.FlashbackAlreadyAvailable"));
+      return;
+    }
+
+    // Reset flashback
     await this.actor.update({ 'system.flashbackUsed': false });
     ui.notifications.info(game.i18n.localize("DIE_RPG.Notifications.Success.FlashbackReset"));
+    // Re-render with header controls update
+    this.render(false, { window: { controls: true } });
   }
 
   /**
@@ -854,6 +903,9 @@ export class DieRpgActorSheet extends api.HandlebarsApplicationMixin(
       ? "DIE_RPG.Notifications.Success.FallenModeEnabled"
       : "DIE_RPG.Notifications.Success.FallenModeDisabled";
     ui.notifications.info(game.i18n.localize(messageKey));
+
+    // Re-render with header controls update
+    this.render(false, { window: { controls: true } });
   }
 
   /**

--- a/src/scss/components/_forms.scss
+++ b/src/scss/components/_forms.scss
@@ -131,6 +131,101 @@ h6 {
 					}
 				}
 
+				.fallen-mode-indicator {
+					display: flex;
+					align-items: center;
+					margin-top: $margin-sm;
+
+					.fallen-mode-toggle {
+						display: flex;
+						align-items: center;
+						gap: 0.25rem;
+						padding: 0.5rem 0.75rem;
+						background: $overlay-dark;
+						border: 1px solid $overlay-dark;
+						border-radius: 4px;
+						cursor: pointer;
+						transition: all 0.2s ease;
+						font-size: 0.9em;
+
+						i {
+							font-size: 1em;
+							color: $c-success;
+						}
+
+						.label {
+							font-weight: 600;
+							color: rgba(255, 255, 255, 0.9);
+						}
+
+						&:hover {
+							background: $overlay-darker;
+							border-color: $overlay-medium;
+
+							i {
+								color: $c-white;
+							}
+
+							.label {
+								color: $c-white;
+							}
+						}
+
+						&.active {
+							background: $c-failure-bg;
+							border-color: $c-failure-border;
+
+							i {
+								color: $c-failure;
+							}
+
+							.label {
+								color: $c-failure;
+							}
+
+							&:hover {
+								background: rgba(139, 0, 0, 0.3);
+								border-color: $c-failure;
+
+								i,
+								.label {
+									filter: brightness(1.2);
+								}
+							}
+						}
+					}
+
+					.fallen-mode-display {
+						display: flex;
+						align-items: center;
+						gap: 0.25rem;
+						padding: 0.5rem 0.75rem;
+						background: $overlay-darker;
+						border-radius: 4px;
+						opacity: 0.8;
+						font-size: 0.9em;
+
+						i {
+							font-size: 1em;
+							color: $c-success;
+						}
+
+						.label {
+							font-weight: 600;
+							color: rgba(255, 255, 255, 0.9);
+						}
+
+						&.active {
+							background: $c-failure-bg;
+
+							i,
+							.label {
+								color: $c-failure;
+							}
+						}
+					}
+				}
+
 				.paragon-selection {
 					display: flex;
 					align-items: center;

--- a/src/scss/components/_paragon.scss
+++ b/src/scss/components/_paragon.scss
@@ -37,4 +37,322 @@
   }
 
   // Specials Section - moved to components/_specials.scss
+
+  // ========================================
+  // FALLEN MODE CONTENT
+  // ========================================
+
+  .fallen-mode-section {
+    display: flex;
+    flex-direction: column;
+    gap: $gap-lg;
+  }
+
+  // Fallen State Info
+  .fallen-state-info {
+    padding: $padding-lg;
+    background: $overlay-dark;
+    border: 1px solid $overlay-medium;
+    border-radius: 4px;
+
+    .section-title {
+      margin: 0 0 $margin-sm 0;
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: $c-failure;
+    }
+
+    .fallen-description {
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
+
+  // Unlife Rules
+  .fallen-rules {
+    padding: $padding-lg;
+    background: $overlay-darker;
+    border-left: 3px solid $overlay-medium;
+    border-radius: 2px;
+
+    h4 {
+      margin: 0 0 $margin-sm 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.95);
+    }
+
+    .rules-list {
+      margin: 0;
+      padding-left: 1.5rem;
+      color: rgba(255, 255, 255, 0.9);
+
+      li {
+        margin-bottom: $margin-sm;
+        line-height: 1.5;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
+  // Fallen Claws
+  .fallen-claws {
+    padding: $padding-lg;
+    background: $overlay-dark;
+    border: 1px solid $overlay-medium;
+    border-radius: 4px;
+
+    h4 {
+      margin: 0 0 $margin-sm 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.95);
+    }
+
+    .claws-description {
+      margin-bottom: $margin-md;
+      line-height: 1.5;
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    .poison-special {
+      padding: $padding-md;
+      background: $overlay-darker;
+      border-left: 3px solid $c-failure-border;
+      border-radius: 2px;
+
+      strong {
+        display: block;
+        margin-bottom: $margin-sm;
+        color: $c-failure;
+        font-size: 0.95rem;
+      }
+
+      p {
+        margin: 0;
+        font-size: 0.875rem;
+        line-height: 1.4;
+        color: rgba(255, 255, 255, 0.85);
+      }
+    }
+  }
+
+  // Monstrous Abilities (reuses NPC abilities styling pattern)
+  .monstrous-abilities-container {
+    .abilities-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: $margin-md;
+
+      h4 {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.95);
+      }
+
+      .add-ability-btn {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+        background: $c-success-bg;
+        color: $c-success-text;
+        border: 1px solid $c-success-border;
+        border-radius: 3px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        i {
+          font-size: 0.625rem;
+        }
+
+        &:hover {
+          background: $c-success;
+          border-color: $c-success;
+          color: $c-white;
+        }
+      }
+    }
+
+    .abilities-list {
+      display: flex;
+      flex-direction: column;
+      gap: $gap-md;
+
+      .hint-text {
+        margin: 0;
+        padding: $padding-md;
+        font-size: 0.875rem;
+        font-style: italic;
+        color: rgba(255, 255, 255, 0.6);
+        background: $overlay-darker;
+        border-radius: 3px;
+        text-align: center;
+      }
+    }
+
+    .monstrous-ability-block {
+      padding: $padding-md;
+      background: $overlay-dark;
+      border: 1px solid $overlay-medium;
+      border-radius: 4px;
+
+      .ability-header {
+        display: flex;
+        gap: $gap-sm;
+        align-items: center;
+        margin-bottom: $margin-md;
+
+        input[type="text"] {
+          flex: 1;
+          font-size: 1rem;
+          font-weight: 600;
+          padding: 0.25rem 0.5rem;
+          background: $overlay-darker;
+          border: 1px solid $overlay-medium;
+          border-radius: 3px;
+          color: rgba(255, 255, 255, 0.95);
+
+          &:focus {
+            outline: none;
+            border-color: $overlay-light;
+          }
+
+          &:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+          }
+        }
+
+        .delete-ability-btn {
+          padding: 0.25rem 0.5rem;
+          background: $c-failure-bg;
+          color: $c-failure;
+          border: 1px solid $c-failure-border;
+          border-radius: 3px;
+          cursor: pointer;
+          transition: all 0.2s ease;
+
+          i {
+            font-size: 0.75rem;
+          }
+
+          &:hover {
+            background: $c-failure;
+            border-color: $c-failure;
+            color: $c-white;
+          }
+        }
+      }
+
+      .ability-description,
+      .ability-customization {
+        margin-bottom: $margin-md;
+
+        label {
+          display: block;
+          margin-bottom: $margin-sm;
+          font-size: 0.875rem;
+          font-weight: 600;
+          color: rgba(255, 255, 255, 0.85);
+        }
+
+        prose-mirror {
+          min-height: 100px;
+          background: $overlay-darker;
+          border: 1px solid $overlay-medium;
+          border-radius: 3px;
+        }
+      }
+
+      .ability-specials {
+        margin-top: $margin-lg;
+        padding-top: $margin-md;
+        border-top: 1px solid $overlay-medium;
+
+        .specials-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: $margin-sm;
+
+          label {
+            font-size: 0.875rem;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.85);
+          }
+
+          .add-special-btn {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.25rem 0.5rem;
+            font-size: 0.75rem;
+            background: $c-success-bg;
+            color: $c-success-text;
+            border: 1px solid $c-success-border;
+            border-radius: 3px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+
+            i {
+              font-size: 0.625rem;
+            }
+
+            &:hover {
+              background: $c-success;
+              border-color: $c-success;
+              color: $c-white;
+            }
+          }
+        }
+
+        .specials-list {
+          display: flex;
+          flex-direction: column;
+          gap: $gap-sm;
+        }
+
+        .hint-text {
+          margin: 0;
+          padding: $padding-sm;
+          font-size: 0.875rem;
+          font-style: italic;
+          color: rgba(255, 255, 255, 0.6);
+          background: $overlay-darkest;
+          border-radius: 3px;
+        }
+      }
+    }
+  }
+
+  // Second Death Warning
+  .second-death-warning {
+    padding: $padding-lg;
+    background: $overlay-dark;
+    border: 1px solid $overlay-medium;
+    border-left: 3px solid $c-failure-border;
+    border-radius: 4px;
+
+    h4 {
+      margin: 0 0 $margin-sm 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: $c-failure;
+    }
+
+    .warning-text {
+      margin: 0;
+      line-height: 1.5;
+      font-size: 0.9375rem;
+      color: rgba(255, 255, 255, 0.9);
+    }
+  }
 }

--- a/templates/actor/character-header.hbs
+++ b/templates/actor/character-header.hbs
@@ -61,6 +61,38 @@
 					<i class="fas fa-redo"></i>
 				</button>
 			</div>
+
+			{{! Fallen mode indicator }}
+			<div class="fallen-mode-indicator">
+				{{#if editable}}
+					<button
+						type="button"
+						class="fallen-mode-toggle {{#if actor.system.fallenMode}}active{{/if}}"
+						data-action="toggleFallenMode"
+						data-tooltip="{{#if actor.system.fallenMode}}{{localize 'DIE_RPG.FallenMode.TooltipReturnToLiving'}}{{else}}{{localize 'DIE_RPG.FallenMode.TooltipEnterFallen'}}{{/if}}"
+					>
+						<i class="fas {{#if actor.system.fallenMode}}fa-skull{{else}}fa-heart{{/if}}"></i>
+						<span class="label">
+							{{#if actor.system.fallenMode}}
+								{{localize "DIE_RPG.FallenMode.LabelFallen"}}
+							{{else}}
+								{{localize "DIE_RPG.FallenMode.LabelLiving"}}
+							{{/if}}
+						</span>
+					</button>
+				{{else}}
+					<div class="fallen-mode-display {{#if actor.system.fallenMode}}active{{/if}}">
+						<i class="fas {{#if actor.system.fallenMode}}fa-skull{{else}}fa-heart{{/if}}"></i>
+						<span class="label">
+							{{#if actor.system.fallenMode}}
+								{{localize "DIE_RPG.FallenMode.LabelFallen"}}
+							{{else}}
+								{{localize "DIE_RPG.FallenMode.LabelLiving"}}
+							{{/if}}
+						</span>
+					</div>
+				{{/if}}
+			</div>
 		</div>
 
 		{{! Right column - Class dice }}

--- a/templates/actor/character-header.hbs
+++ b/templates/actor/character-header.hbs
@@ -39,60 +39,6 @@
 					placeholder="{{localize 'DIE_RPG.UI.Placeholders.Name'}}"
 				/>
 			</div>
-
-			{{! Character flashback indicator }}
-			<div class="flashback-indicator">
-				<span class="flashback-status {{#if actor.system.flashbackUsed}}used{{else}}available{{/if}}">
-					<i class="fas fa-history"></i>
-					{{localize "DIE_RPG.UI.Labels.Flashback"}}
-					{{#if actor.system.flashbackUsed}}
-						<span class="status-text">{{localize "DIE_RPG.UI.Status.Used"}}</span>
-					{{else}}
-						<span class="status-text">{{localize "DIE_RPG.UI.Status.Available"}}</span>
-					{{/if}}
-				</span>
-				<button
-					type="button"
-					class="reset-flashback-btn"
-					data-action="resetFlashback"
-					data-tooltip="{{localize 'DIE_RPG.Actor.Character.ResetFlashback'}}"
-					{{#unless actor.system.flashbackUsed}}disabled{{/unless}}
-				>
-					<i class="fas fa-redo"></i>
-				</button>
-			</div>
-
-			{{! Fallen mode indicator }}
-			<div class="fallen-mode-indicator">
-				{{#if editable}}
-					<button
-						type="button"
-						class="fallen-mode-toggle {{#if actor.system.fallenMode}}active{{/if}}"
-						data-action="toggleFallenMode"
-						data-tooltip="{{#if actor.system.fallenMode}}{{localize 'DIE_RPG.FallenMode.TooltipReturnToLiving'}}{{else}}{{localize 'DIE_RPG.FallenMode.TooltipEnterFallen'}}{{/if}}"
-					>
-						<i class="fas {{#if actor.system.fallenMode}}fa-skull{{else}}fa-heart{{/if}}"></i>
-						<span class="label">
-							{{#if actor.system.fallenMode}}
-								{{localize "DIE_RPG.FallenMode.LabelFallen"}}
-							{{else}}
-								{{localize "DIE_RPG.FallenMode.LabelLiving"}}
-							{{/if}}
-						</span>
-					</button>
-				{{else}}
-					<div class="fallen-mode-display {{#if actor.system.fallenMode}}active{{/if}}">
-						<i class="fas {{#if actor.system.fallenMode}}fa-skull{{else}}fa-heart{{/if}}"></i>
-						<span class="label">
-							{{#if actor.system.fallenMode}}
-								{{localize "DIE_RPG.FallenMode.LabelFallen"}}
-							{{else}}
-								{{localize "DIE_RPG.FallenMode.LabelLiving"}}
-							{{/if}}
-						</span>
-					</div>
-				{{/if}}
-			</div>
 		</div>
 
 		{{! Right column - Class dice }}

--- a/templates/actor/fallen.hbs
+++ b/templates/actor/fallen.hbs
@@ -1,0 +1,165 @@
+{{! Fallen Tab }}
+<section
+  class='tab fallen {{tab.cssClass}}'
+  data-group='primary'
+  data-tab='fallen'
+>
+	<div class="fallen-mode-section">
+
+		{{! Fallen State Info }}
+		<div class="fallen-state-info">
+			<h3 class="section-title">{{localize "DIE_RPG.FallenMode.Title"}}</h3>
+			<div class="fallen-description">
+				<p>{{{localize "DIE_RPG.FallenMode.Description"}}}</p>
+			</div>
+		</div>
+
+		{{! Unlife Rules }}
+		<div class="fallen-rules">
+			<h4>{{localize "DIE_RPG.FallenMode.UnlifeRules.Title"}}</h4>
+			<ul class="rules-list">
+				<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.LostAbilities"}}}</li>
+				<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.Resurrection"}}}</li>
+				<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.VoteDoesNotCount"}}}</li>
+			</ul>
+		</div>
+
+		{{! Fallen Claws }}
+		<div class="fallen-claws">
+			<h4>{{localize "DIE_RPG.FallenMode.FallenClaws.Title"}}</h4>
+			<p class="claws-description">{{{localize "DIE_RPG.FallenMode.FallenClaws.Description"}}}</p>
+			<div class="poison-special">
+				<strong>{{localize "DIE_RPG.FallenMode.FallenClaws.PoisonLabel"}}</strong>
+				<p>{{{localize "DIE_RPG.FallenMode.FallenClaws.PoisonEffect"}}}</p>
+			</div>
+		</div>
+
+		{{! Monstrous Abilities }}
+		<div class="monstrous-abilities-container">
+			<div class="abilities-header">
+				<h4>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.Title"}}</h4>
+				{{#if editable}}
+					<button
+						type="button"
+						class="add-ability-btn"
+						data-action="addMonstrousAbility"
+						data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.AddTooltip'}}"
+					>
+						<i class="fas fa-plus"></i>
+						{{localize "DIE_RPG.FallenMode.MonstrousAbilities.AddButton"}}
+					</button>
+				{{/if}}
+			</div>
+
+			<div class="abilities-list">
+				{{#if actor.system.monstrousAbilities.length}}
+					{{#each actor.system.monstrousAbilities as |ability index|}}
+						<div class="ability-block monstrous-ability-block" data-ability-index="{{index}}">
+
+							{{! Ability Header: Name + Delete }}
+							<div class="ability-header">
+								<input
+									type="text"
+									name="system.monstrousAbilities.{{index}}.name"
+									value="{{ability.name}}"
+									placeholder="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.NamePlaceholder'}}"
+									{{#unless ../editable}}disabled{{/unless}}
+								/>
+								{{#if ../editable}}
+									<button
+										type="button"
+										class="delete-ability-btn"
+										data-action="deleteMonstrousAbility"
+										data-ability-index="{{index}}"
+										data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.DeleteTooltip'}}"
+									>
+										<i class="fas fa-trash"></i>
+									</button>
+								{{/if}}
+							</div>
+
+							{{! Ability Description }}
+							<div class="ability-description">
+								<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.DescriptionLabel"}}</label>
+								<prose-mirror
+									name="system.monstrousAbilities.{{index}}.description"
+									data-document-u-u-i-d="{{../actor.uuid}}"
+									value="{{ability.description}}"
+									collaborate="true"
+									toggled="true"
+									compact="true"
+									{{#unless ../editable}}editable="false"{{/unless}}
+								>
+									{{{ability.description}}}
+								</prose-mirror>
+			</div>
+
+							{{! Customization Field }}
+							<div class="ability-customization">
+								<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.CustomizationLabel"}}</label>
+								<prose-mirror
+									name="system.monstrousAbilities.{{index}}.customization"
+									data-document-u-u-i-d="{{../actor.uuid}}"
+									value="{{ability.customization}}"
+									collaborate="true"
+									toggled="true"
+									compact="true"
+									{{#unless ../editable}}editable="false"{{/unless}}
+								>
+									{{{ability.customization}}}
+								</prose-mirror>
+							</div>
+
+							{{! Specials Subsection }}
+							<div class="ability-specials">
+								<div class="specials-header">
+									<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.SpecialsLabel"}}</label>
+									{{#if ../editable}}
+										<button
+											type="button"
+											class="add-special-btn"
+											data-action="addSpecial"
+											data-ability-index="{{index}}"
+											data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.AddSpecialTooltip'}}"
+										>
+											<i class="fas fa-plus"></i>
+											{{localize "DIE_RPG.FallenMode.MonstrousAbilities.AddSpecialButton"}}
+										</button>
+									{{/if}}
+								</div>
+
+								{{#if ability.specials.length}}
+									<div class="specials-list">
+										{{#each ability.specials as |special specialIndex|}}
+											{{> "systems/die-rpg/templates/partials/special-item.hbs"
+												special=special
+												index=specialIndex
+												basePath=(concat "system.monstrousAbilities." ../index ".specials")
+												documentUuid=../../actor.uuid
+												editable=../../editable
+												deleteAction="deleteSpecial"
+												deleteDataAttrs=(concat "data-ability-index='" ../index "' data-special-index='" specialIndex "'")
+											}}
+										{{/each}}
+									</div>
+								{{else}}
+									<p class="hint-text">{{localize "DIE_RPG.FallenMode.MonstrousAbilities.NoSpecials"}}</p>
+								{{/if}}
+							</div>
+
+						</div>
+					{{/each}}
+				{{else}}
+					<p class="hint-text">{{localize "DIE_RPG.FallenMode.MonstrousAbilities.NoAbilities"}}</p>
+				{{/if}}
+			</div>
+		</div>
+
+		{{! Second Death Warning }}
+		<div class="second-death-warning">
+			<h4>{{localize "DIE_RPG.FallenMode.SecondDeath.Title"}}</h4>
+			<p class="warning-text">{{{localize "DIE_RPG.FallenMode.SecondDeath.Description"}}}</p>
+		</div>
+
+	</div>
+</section>

--- a/templates/actor/paragon.hbs
+++ b/templates/actor/paragon.hbs
@@ -4,31 +4,202 @@
   data-group='primary'
   data-tab='paragon'
 >
+	{{! Living Mode Content - requires paragon }}
 	{{#if paragonItem}}
-		<div class="paragon-tab-content">
-
-			{{! Class Abilities Section - Dynamic Fields from Paragon }}
-			{{#if paragonItem.system.classAbilities.fields.length}}
-				<div class="class-abilities-section">
-					<h3>{{localize "DIE_RPG.UI.Headers.ClassAbilities"}}</h3>
-					<div class="class-abilities-form">
-						{{#each paragonItem.system.classAbilities.fields as |field|}}
-							{{> "systems/die-rpg/templates/partials/dynamic-field.hbs"
-								field=field
-								value=(lookup @root.actor.system.paragon.classAbilityData field.key)
-								enrichedValue=(lookup @root.enrichedClassAbilityData field.key)
-								path=(concat "system.paragon.classAbilityData." field.key)
-								editable=@root.editable
-								actor=@root.actor
-								paragonItem=@root.paragonItem}}
-						{{/each}}
+		{{#unless actor.system.fallenMode}}
+			<div class="paragon-tab-content">
+				{{! Class Abilities Section - Dynamic Fields from Paragon }}
+				{{#if paragonItem.system.classAbilities.fields.length}}
+					<div class="class-abilities-section">
+						<h3>{{localize "DIE_RPG.UI.Headers.ClassAbilities"}}</h3>
+						<div class="class-abilities-form">
+							{{#each paragonItem.system.classAbilities.fields as |field|}}
+								{{> "systems/die-rpg/templates/partials/dynamic-field.hbs"
+									field=field
+									value=(lookup @root.actor.system.paragon.classAbilityData field.key)
+									enrichedValue=(lookup @root.enrichedClassAbilityData field.key)
+									path=(concat "system.paragon.classAbilityData." field.key)
+									editable=@root.editable
+									actor=@root.actor
+									paragonItem=@root.paragonItem}}
+							{{/each}}
+						</div>
 					</div>
+				{{/if}}
+			</div>
+		{{/unless}}
+	{{/if}}
+
+	{{! Fallen Mode Content - doesn't require paragon }}
+	{{#if actor.system.fallenMode}}
+		<div class="paragon-tab-content">
+			<div class="fallen-mode-section">
+
+				{{! Fallen State Info }}
+				<div class="fallen-state-info">
+						<h3 class="section-title">{{localize "DIE_RPG.FallenMode.Title"}}</h3>
+						<div class="fallen-description">
+							<p>{{{localize "DIE_RPG.FallenMode.Description"}}}</p>
+						</div>
+					</div>
+
+					{{! Unlife Rules }}
+					<div class="fallen-rules">
+						<h4>{{localize "DIE_RPG.FallenMode.UnlifeRules.Title"}}</h4>
+						<ul class="rules-list">
+							<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.LostAbilities"}}}</li>
+							<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.Resurrection"}}}</li>
+							<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.VoteDoesNotCount"}}}</li>
+						</ul>
+					</div>
+
+					{{! Fallen Claws }}
+					<div class="fallen-claws">
+						<h4>{{localize "DIE_RPG.FallenMode.FallenClaws.Title"}}</h4>
+						<p class="claws-description">{{{localize "DIE_RPG.FallenMode.FallenClaws.Description"}}}</p>
+						<div class="poison-special">
+							<strong>{{localize "DIE_RPG.FallenMode.FallenClaws.PoisonLabel"}}</strong>
+							<p>{{{localize "DIE_RPG.FallenMode.FallenClaws.PoisonEffect"}}}</p>
+						</div>
+					</div>
+
+					{{! Monstrous Abilities }}
+					<div class="monstrous-abilities-container">
+						<div class="abilities-header">
+							<h4>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.Title"}}</h4>
+							{{#if editable}}
+								<button
+									type="button"
+									class="add-ability-btn"
+									data-action="addMonstrousAbility"
+									data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.AddTooltip'}}"
+								>
+									<i class="fas fa-plus"></i>
+									{{localize "DIE_RPG.FallenMode.MonstrousAbilities.AddButton"}}
+								</button>
+							{{/if}}
+						</div>
+
+						<div class="abilities-list">
+							{{#if actor.system.monstrousAbilities.length}}
+								{{#each actor.system.monstrousAbilities as |ability index|}}
+									<div class="ability-block monstrous-ability-block" data-ability-index="{{index}}">
+
+										{{! Ability Header: Name + Delete }}
+										<div class="ability-header">
+											<input
+												type="text"
+												name="system.monstrousAbilities.{{index}}.name"
+												value="{{ability.name}}"
+												placeholder="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.NamePlaceholder'}}"
+												{{#unless ../editable}}disabled{{/unless}}
+											/>
+											{{#if ../editable}}
+												<button
+													type="button"
+													class="delete-ability-btn"
+													data-action="deleteMonstrousAbility"
+													data-ability-index="{{index}}"
+													data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.DeleteTooltip'}}"
+												>
+													<i class="fas fa-trash"></i>
+												</button>
+											{{/if}}
+										</div>
+
+										{{! Ability Description }}
+										<div class="ability-description">
+											<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.DescriptionLabel"}}</label>
+											<prose-mirror
+												name="system.monstrousAbilities.{{index}}.description"
+												data-document-u-u-i-d="{{../actor.uuid}}"
+												value="{{ability.description}}"
+												collaborate="true"
+												toggled="true"
+												compact="true"
+												{{#unless ../editable}}editable="false"{{/unless}}
+											>
+												{{{ability.description}}}
+											</prose-mirror>
+										</div>
+
+										{{! Customization Field }}
+										<div class="ability-customization">
+											<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.CustomizationLabel"}}</label>
+											<prose-mirror
+												name="system.monstrousAbilities.{{index}}.customization"
+												data-document-u-u-i-d="{{../actor.uuid}}"
+												value="{{ability.customization}}"
+												collaborate="true"
+												toggled="true"
+												compact="true"
+												{{#unless ../editable}}editable="false"{{/unless}}
+											>
+												{{{ability.customization}}}
+											</prose-mirror>
+										</div>
+
+										{{! Specials Subsection }}
+										<div class="ability-specials">
+											<div class="specials-header">
+												<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.SpecialsLabel"}}</label>
+												{{#if ../editable}}
+													<button
+														type="button"
+														class="add-special-btn"
+														data-action="addSpecial"
+														data-ability-index="{{index}}"
+														data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.AddSpecialTooltip'}}"
+													>
+														<i class="fas fa-plus"></i>
+														{{localize "DIE_RPG.FallenMode.MonstrousAbilities.AddSpecialButton"}}
+													</button>
+												{{/if}}
+											</div>
+
+											{{#if ability.specials.length}}
+												<div class="specials-list">
+													{{#each ability.specials as |special specialIndex|}}
+														{{> "systems/die-rpg/templates/partials/special-item.hbs"
+															special=special
+															index=specialIndex
+															basePath=(concat "system.monstrousAbilities." ../index ".specials")
+															documentUuid=../../actor.uuid
+															editable=../../editable
+															deleteAction="deleteSpecial"
+															deleteDataAttrs=(concat "data-ability-index='" ../index "' data-special-index='" specialIndex "'")
+														}}
+													{{/each}}
+												</div>
+											{{else}}
+												<p class="hint-text">{{localize "DIE_RPG.FallenMode.MonstrousAbilities.NoSpecials"}}</p>
+											{{/if}}
+										</div>
+
+									</div>
+								{{/each}}
+							{{else}}
+								<p class="hint-text">{{localize "DIE_RPG.FallenMode.MonstrousAbilities.NoAbilities"}}</p>
+							{{/if}}
+						</div>
+					</div>
+
+					{{! Second Death Warning }}
+					<div class="second-death-warning">
+						<h4>{{localize "DIE_RPG.FallenMode.SecondDeath.Title"}}</h4>
+						<p class="warning-text">{{{localize "DIE_RPG.FallenMode.SecondDeath.Description"}}}</p>
+					</div>
+
 				</div>
-			{{/if}}
-		</div>
-	{{else}}
-		<div class="no-paragon-message">
-			<p>{{localize "DIE_RPG.UI.EmptyStates.SelectParagonForClassInfo"}}</p>
 		</div>
 	{{/if}}
+
+	{{! No paragon message - only show when not fallen and no paragon }}
+	{{#unless actor.system.fallenMode}}
+		{{#unless paragonItem}}
+			<div class="no-paragon-message">
+				<p>{{localize "DIE_RPG.UI.EmptyStates.SelectParagonForClassInfo"}}</p>
+			</div>
+		{{/unless}}
+	{{/unless}}
 </section>

--- a/templates/actor/paragon.hbs
+++ b/templates/actor/paragon.hbs
@@ -4,202 +4,30 @@
   data-group='primary'
   data-tab='paragon'
 >
-	{{! Living Mode Content - requires paragon }}
 	{{#if paragonItem}}
-		{{#unless actor.system.fallenMode}}
-			<div class="paragon-tab-content">
-				{{! Class Abilities Section - Dynamic Fields from Paragon }}
-				{{#if paragonItem.system.classAbilities.fields.length}}
-					<div class="class-abilities-section">
-						<h3>{{localize "DIE_RPG.UI.Headers.ClassAbilities"}}</h3>
-						<div class="class-abilities-form">
-							{{#each paragonItem.system.classAbilities.fields as |field|}}
-								{{> "systems/die-rpg/templates/partials/dynamic-field.hbs"
-									field=field
-									value=(lookup @root.actor.system.paragon.classAbilityData field.key)
-									enrichedValue=(lookup @root.enrichedClassAbilityData field.key)
-									path=(concat "system.paragon.classAbilityData." field.key)
-									editable=@root.editable
-									actor=@root.actor
-									paragonItem=@root.paragonItem}}
-							{{/each}}
-						</div>
-					</div>
-				{{/if}}
-			</div>
-		{{/unless}}
-	{{/if}}
-
-	{{! Fallen Mode Content - doesn't require paragon }}
-	{{#if actor.system.fallenMode}}
 		<div class="paragon-tab-content">
-			<div class="fallen-mode-section">
-
-				{{! Fallen State Info }}
-				<div class="fallen-state-info">
-						<h3 class="section-title">{{localize "DIE_RPG.FallenMode.Title"}}</h3>
-						<div class="fallen-description">
-							<p>{{{localize "DIE_RPG.FallenMode.Description"}}}</p>
-						</div>
+			{{! Class Abilities Section - Dynamic Fields from Paragon }}
+			{{#if paragonItem.system.classAbilities.fields.length}}
+				<div class="class-abilities-section">
+					<h3>{{localize "DIE_RPG.UI.Headers.ClassAbilities"}}</h3>
+					<div class="class-abilities-form">
+						{{#each paragonItem.system.classAbilities.fields as |field|}}
+							{{> "systems/die-rpg/templates/partials/dynamic-field.hbs"
+								field=field
+								value=(lookup @root.actor.system.paragon.classAbilityData field.key)
+								enrichedValue=(lookup @root.enrichedClassAbilityData field.key)
+								path=(concat "system.paragon.classAbilityData." field.key)
+								editable=@root.editable
+								actor=@root.actor
+								paragonItem=@root.paragonItem}}
+						{{/each}}
 					</div>
-
-					{{! Unlife Rules }}
-					<div class="fallen-rules">
-						<h4>{{localize "DIE_RPG.FallenMode.UnlifeRules.Title"}}</h4>
-						<ul class="rules-list">
-							<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.LostAbilities"}}}</li>
-							<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.Resurrection"}}}</li>
-							<li>{{{localize "DIE_RPG.FallenMode.UnlifeRules.VoteDoesNotCount"}}}</li>
-						</ul>
-					</div>
-
-					{{! Fallen Claws }}
-					<div class="fallen-claws">
-						<h4>{{localize "DIE_RPG.FallenMode.FallenClaws.Title"}}</h4>
-						<p class="claws-description">{{{localize "DIE_RPG.FallenMode.FallenClaws.Description"}}}</p>
-						<div class="poison-special">
-							<strong>{{localize "DIE_RPG.FallenMode.FallenClaws.PoisonLabel"}}</strong>
-							<p>{{{localize "DIE_RPG.FallenMode.FallenClaws.PoisonEffect"}}}</p>
-						</div>
-					</div>
-
-					{{! Monstrous Abilities }}
-					<div class="monstrous-abilities-container">
-						<div class="abilities-header">
-							<h4>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.Title"}}</h4>
-							{{#if editable}}
-								<button
-									type="button"
-									class="add-ability-btn"
-									data-action="addMonstrousAbility"
-									data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.AddTooltip'}}"
-								>
-									<i class="fas fa-plus"></i>
-									{{localize "DIE_RPG.FallenMode.MonstrousAbilities.AddButton"}}
-								</button>
-							{{/if}}
-						</div>
-
-						<div class="abilities-list">
-							{{#if actor.system.monstrousAbilities.length}}
-								{{#each actor.system.monstrousAbilities as |ability index|}}
-									<div class="ability-block monstrous-ability-block" data-ability-index="{{index}}">
-
-										{{! Ability Header: Name + Delete }}
-										<div class="ability-header">
-											<input
-												type="text"
-												name="system.monstrousAbilities.{{index}}.name"
-												value="{{ability.name}}"
-												placeholder="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.NamePlaceholder'}}"
-												{{#unless ../editable}}disabled{{/unless}}
-											/>
-											{{#if ../editable}}
-												<button
-													type="button"
-													class="delete-ability-btn"
-													data-action="deleteMonstrousAbility"
-													data-ability-index="{{index}}"
-													data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.DeleteTooltip'}}"
-												>
-													<i class="fas fa-trash"></i>
-												</button>
-											{{/if}}
-										</div>
-
-										{{! Ability Description }}
-										<div class="ability-description">
-											<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.DescriptionLabel"}}</label>
-											<prose-mirror
-												name="system.monstrousAbilities.{{index}}.description"
-												data-document-u-u-i-d="{{../actor.uuid}}"
-												value="{{ability.description}}"
-												collaborate="true"
-												toggled="true"
-												compact="true"
-												{{#unless ../editable}}editable="false"{{/unless}}
-											>
-												{{{ability.description}}}
-											</prose-mirror>
-										</div>
-
-										{{! Customization Field }}
-										<div class="ability-customization">
-											<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.CustomizationLabel"}}</label>
-											<prose-mirror
-												name="system.monstrousAbilities.{{index}}.customization"
-												data-document-u-u-i-d="{{../actor.uuid}}"
-												value="{{ability.customization}}"
-												collaborate="true"
-												toggled="true"
-												compact="true"
-												{{#unless ../editable}}editable="false"{{/unless}}
-											>
-												{{{ability.customization}}}
-											</prose-mirror>
-										</div>
-
-										{{! Specials Subsection }}
-										<div class="ability-specials">
-											<div class="specials-header">
-												<label>{{localize "DIE_RPG.FallenMode.MonstrousAbilities.SpecialsLabel"}}</label>
-												{{#if ../editable}}
-													<button
-														type="button"
-														class="add-special-btn"
-														data-action="addSpecial"
-														data-ability-index="{{index}}"
-														data-tooltip="{{localize 'DIE_RPG.FallenMode.MonstrousAbilities.AddSpecialTooltip'}}"
-													>
-														<i class="fas fa-plus"></i>
-														{{localize "DIE_RPG.FallenMode.MonstrousAbilities.AddSpecialButton"}}
-													</button>
-												{{/if}}
-											</div>
-
-											{{#if ability.specials.length}}
-												<div class="specials-list">
-													{{#each ability.specials as |special specialIndex|}}
-														{{> "systems/die-rpg/templates/partials/special-item.hbs"
-															special=special
-															index=specialIndex
-															basePath=(concat "system.monstrousAbilities." ../index ".specials")
-															documentUuid=../../actor.uuid
-															editable=../../editable
-															deleteAction="deleteSpecial"
-															deleteDataAttrs=(concat "data-ability-index='" ../index "' data-special-index='" specialIndex "'")
-														}}
-													{{/each}}
-												</div>
-											{{else}}
-												<p class="hint-text">{{localize "DIE_RPG.FallenMode.MonstrousAbilities.NoSpecials"}}</p>
-											{{/if}}
-										</div>
-
-									</div>
-								{{/each}}
-							{{else}}
-								<p class="hint-text">{{localize "DIE_RPG.FallenMode.MonstrousAbilities.NoAbilities"}}</p>
-							{{/if}}
-						</div>
-					</div>
-
-					{{! Second Death Warning }}
-					<div class="second-death-warning">
-						<h4>{{localize "DIE_RPG.FallenMode.SecondDeath.Title"}}</h4>
-						<p class="warning-text">{{{localize "DIE_RPG.FallenMode.SecondDeath.Description"}}}</p>
-					</div>
-
 				</div>
+			{{/if}}
+		</div>
+	{{else}}
+		<div class="no-paragon-message">
+			<p>{{localize "DIE_RPG.UI.EmptyStates.SelectParagonForClassInfo"}}</p>
 		</div>
 	{{/if}}
-
-	{{! No paragon message - only show when not fallen and no paragon }}
-	{{#unless actor.system.fallenMode}}
-		{{#unless paragonItem}}
-			<div class="no-paragon-message">
-				<p>{{localize "DIE_RPG.UI.EmptyStates.SelectParagonForClassInfo"}}</p>
-			</div>
-		{{/unless}}
-	{{/unless}}
 </section>


### PR DESCRIPTION
adds:
- campaign vs ritual setting
- Setting used to determine how fallen mode works
- Fallen mode added, creates a new fallen tab with fallen abilities (hides paragon tab in ritual mode)
- adds fallen mode button to the sheet header dropdown
- moved the reset flashback to the sheet header dropdown